### PR TITLE
Remove explicit dependency on sybil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[lib] == 0.9.1",
+  "frequenz-repo-config[lib] == 0.9.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -70,7 +70,7 @@ dev-mkdocs = [
   "mkdocs-macros-plugin == 1.0.5",
   "mkdocs-material == 9.5.17",
   "mkdocstrings[python] == 0.24.2",
-  "frequenz-repo-config[lib] == 0.9.1",
+  "frequenz-repo-config[lib] == 0.9.2",
 ]
 dev-mypy = [
   "mypy == 1.9.0",
@@ -82,7 +82,7 @@ dev-mypy = [
 dev-noxfile = [
   "uv == 0.1.28",
   "nox == 2024.3.02",
-  "frequenz-repo-config[lib] == 0.9.1",
+  "frequenz-repo-config[lib] == 0.9.2",
 ]
 dev-pylint = [
   "pylint == 3.1.0",
@@ -91,7 +91,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 8.1.1",
-  "frequenz-repo-config[extra-lint-examples] == 0.9.1",
+  "frequenz-repo-config[extra-lint-examples] == 0.9.2",
   "pytest-mock == 3.14.0",
   "pytest-asyncio == 0.23.6",
   "async-solipsism == 0.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,15 @@ name = "frequenz-dispatch"
 description = "A highlevel interface for the dispatch API"
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["frequenz", "python", "actor", "frequenz-dispatch", "dispatch", "highlevel", "api"]
+keywords = [
+  "frequenz",
+  "python",
+  "actor",
+  "frequenz-dispatch",
+  "dispatch",
+  "highlevel",
+  "api",
+]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
@@ -88,8 +96,6 @@ dev-pytest = [
   "pytest-asyncio == 0.23.6",
   "async-solipsism == 0.6",
   "time-machine == 2.14.1",
-  # Currently pinned due to v6.1.0 breaking our code
-  "sybil == 6.0.3",
 ]
 dev = [
   "frequenz-dispatch[dev-mkdocs,dev-flake8,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",
@@ -171,11 +177,7 @@ packages = ["frequenz.dispatch"]
 strict = true
 
 [[tool.mypy.overrides]]
-module = [
-  "mkdocs_macros.*",
-  "async_solipsism",
-  "async_solipsism.*",
-]
+module = ["mkdocs_macros.*", "async_solipsism", "async_solipsism.*"]
 ignore_missing_imports = true
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This dependency is used by repo-config, not us directly.
