### PR TITLE
Don't recursively scan for pyproject.toml when calculating the cache key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/pip-cache
-          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('**/pyproject.toml') }}
+          key: nox-${{ matrix.nox-session }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
 
       # This ensures that the docker container has access to the pip cache.
       # Changing the user in the docker-run step causes it to fail due to


### PR DESCRIPTION
We don't really need to scan for `pyproject.toml` files recursively,
since we only have one in the root of the repository. This should make
the cache key calculation more efficient and less error prone, as when
using qemu, there are some files that are not accessible and the hash
calculation fails.
