### PR TITLE
Fix running state behavior with delete

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,7 @@
 ## Upgrading
 
 * An API key for authorization must now be passed to the client.
+
+## Bug Fixes
+
+* When a dispatch is deleted, the running state change notification telling the actor that it is no longer running will only be sent if there are no other dispatches of the same type running.

--- a/src/frequenz/dispatch/_dispatcher.py
+++ b/src/frequenz/dispatch/_dispatcher.py
@@ -268,6 +268,9 @@ class Dispatcher:
         or reconfigure itself with new parameters causes a message to be
         sent.
 
+        Note, that when a dispatch is deleted, a message will only be sent if no
+        other dispatch of the same type is still running.
+
         A non-exhaustive list of possible changes that will cause a message to be sent:
          - The normal scheduled start_time has been reached
          - The duration of the dispatch has been modified


### PR DESCRIPTION
When a dispatch is deleted, the running state change notification telling the actor that it is no longer running will only be sent if there are no other dispatches of the same type running.

Signed-off-by: Mathias L. Baumann <mathias.baumann@frequenz.com>
