### PR TITLE
Bump the cross-ref object DB version to match the dependency version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Dispatch Highlevel Interface Release Notes
 
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
 ## Upgrading
 
-* An API key for authorization must now be passed to the client.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix documentation cross-linking to the `frequenz-client-dispatch` package.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,7 @@ plugins:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
             - https://frequenz-floss.github.io/frequenz-channels-python/v1.0/objects.inv
-            - https://frequenz-floss.github.io/frequenz-client-dispatch-python/v0.2/objects.inv
+            - https://frequenz-floss.github.io/frequenz-client-dispatch-python/v0.5/objects.inv
             - https://frequenz-floss.github.io/frequenz-sdk-python/v1.0-pre/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv


### PR DESCRIPTION
The `frequenz-client-dispatch-python` dependency was updated to `0.5`, but the cross-ref object DB version was not updated to match it, so cross linking is sending users to the wrong version.
