### PR TITLE
Extend `frequenz-sdk` dependency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,4 @@
 
 ## Summary
 
-* This fixes a crash when the `YEARLY` frequency is used in a dispatch.
+* `frequenz-sdk` dependency has been extended to include version `1.0.0-rc1000`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   # Make sure to update the version for cross-referencing also in the
   # mkdocs.yml file when changing the version here (look for the config key
   # plugins.mkdocstrings.handlers.python.import)
-  "frequenz-sdk >= 1.0.0-rc900, < 1.0.0-rc1000",
+  "frequenz-sdk >= 1.0.0-rc900, < 1.0.0-rc1100",
   "frequenz-channels >= 1.2.0, < 2.0.0",
   "frequenz-client-dispatch >= 0.7.1, < 0.8.0",
 ]


### PR DESCRIPTION
The latest `frequenz-sdk` version `1.0.0-rc1000` is required for actor applications to include the most recent bug fixes and features in the SDK.