### PR TITLE
Fix recurrence

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,4 @@
 
 ## Summary
 
-* `frequenz-sdk` dependency has been extended to include version `1.0.0-rc1000`.
+This is a hot fix for recurrence not working

--- a/src/frequenz/dispatch/_dispatch.py
+++ b/src/frequenz/dispatch/_dispatch.py
@@ -222,13 +222,14 @@ class Dispatch(BaseDispatch):
             dtstart=self.start_time,
             count=count,
             until=until,
-            byminute=self.recurrence.byminutes,
-            byhour=self.recurrence.byhours,
+            byminute=self.recurrence.byminutes or None,
+            byhour=self.recurrence.byhours or None,
             byweekday=[
                 _RRULE_WEEKDAY_MAP[weekday] for weekday in self.recurrence.byweekdays
-            ],
-            bymonthday=self.recurrence.bymonthdays,
-            bymonth=self.recurrence.bymonths,
+            ]
+            or None,
+            bymonthday=self.recurrence.bymonthdays or None,
+            bymonth=self.recurrence.bymonths or None,
             interval=self.recurrence.interval,
         )
 


### PR DESCRIPTION
Recurrence didn't properly work as we passed in the
empty list for the by-* fiedls by default
which means "No valid time-unit",
e.g bymonth=[] means no month at all. never.
