### PR TITLE
Fix crash when dispatches share equal start time

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,16 @@
 
 ## Summary
 
-This is a hot fix for recurrence not working
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+* Fixed a crash in the `DispatchManagingActor` when dispatches shared an equal start time.

--- a/src/frequenz/dispatch/_dispatch.py
+++ b/src/frequenz/dispatch/_dispatch.py
@@ -211,11 +211,17 @@ class Dispatch(BaseDispatch):
 
         Returns:
             The rrule object.
+
+        Raises:
+            ValueError: If the interval is invalid.
         """
         count, until = (None, None)
         if end := self.recurrence.end_criteria:
             count = end.count
             until = end.until
+
+        if self.recurrence.interval is None or self.recurrence.interval < 1:
+            raise ValueError("Interval must be at least 1")
 
         rrule_obj = rrule.rrule(
             freq=_RRULE_FREQ_MAP[self.recurrence.frequency],


### PR DESCRIPTION
- **Fix exception when two dispatches have equal start time**
- **Ensure we don't accidentally work on invalid rrules**

fixes https://github.com/frequenz-floss/frequenz-dispatch-python/issues/74
