### PR TITLE
Merge & unify running state event intervals

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,12 +7,12 @@
 ## Upgrading
 
 * Two properties have been replaced by methods that require a type as parameter.
-    * `Dispatcher.lifecycle_events` has been replaced by the method `Dispatcher.new_lifecycle_events_receiver(self, type: str)`.
-    * `Dispatcher.running_status_change` has been replaced by the method `Dispatcher.new_running_state_event_receiver(self, type: str)`.
+    * `Dispatcher.lifecycle_events` has been replaced by the method `Dispatcher.new_lifecycle_events_receiver(self, dispatch_type: str)`.
+    * `Dispatcher.running_status_change` has been replaced by the method `Dispatcher.new_running_state_event_receiver(self, dispatch_type: str, unify_running_intervals: bool)`.
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* A new feature "unify running intervals" has been added to the `Dispatcher.new_running_state_event_receiver` method. Using it, you can automatically merge & unify consecutive and overlapping dispatch start/stop events of the same type. E.g. dispatch `A` starting at 10:10 and ending at 10:30 and dispatch `B` starts at 10:30 until 11:00, with the feature enabled this would in total trigger one start event, one reconfigure event at 10:30 and one stop event at 11:00.
 
 ## Bug Fixes
 

--- a/src/frequenz/dispatch/_dispatcher.py
+++ b/src/frequenz/dispatch/_dispatcher.py
@@ -200,7 +200,7 @@ class Dispatcher:
         return self._bg_service.new_lifecycle_events_receiver(dispatch_type)
 
     async def new_running_state_event_receiver(
-        self, dispatch_type: str
+        self, dispatch_type: str, unify_running_intervals: bool = True
     ) -> Receiver[Dispatch]:
         """Return running state event receiver.
 
@@ -228,10 +228,18 @@ class Dispatcher:
          - The payload changed
          - The dispatch was deleted
 
+        If `unify_running_intervals` is True, running intervals from multiple
+        dispatches of the same type are considered as one continuous running
+        period. In this mode, any stop events are ignored as long as at least
+        one dispatch remains active.
+
         Args:
             dispatch_type: The type of the dispatch to listen for.
+            unify_running_intervals: Whether to unify running intervals.
 
         Returns:
             A new receiver for dispatches whose running status changed.
         """
-        return await self._bg_service.new_running_state_event_receiver(dispatch_type)
+        return await self._bg_service.new_running_state_event_receiver(
+            dispatch_type, unify_running_intervals
+        )

--- a/src/frequenz/dispatch/_dispatcher.py
+++ b/src/frequenz/dispatch/_dispatcher.py
@@ -200,7 +200,7 @@ class Dispatcher:
         return self._bg_service.new_lifecycle_events_receiver(dispatch_type)
 
     async def new_running_state_event_receiver(
-        self, dispatch_type: str, unify_running_intervals: bool = True
+        self, dispatch_type: str, *, unify_running_intervals: bool = True
     ) -> Receiver[Dispatch]:
         """Return running state event receiver.
 
@@ -241,5 +241,5 @@ class Dispatcher:
             A new receiver for dispatches whose running status changed.
         """
         return await self._bg_service.new_running_state_event_receiver(
-            dispatch_type, unify_running_intervals
+            dispatch_type, unify_running_intervals=unify_running_intervals
         )

--- a/tests/test_mananging_actor.py
+++ b/tests/test_mananging_actor.py
@@ -147,12 +147,38 @@ def test_heapq_dispatch_compare(test_env: TestEnv) -> None:
     # Push two events with the same 'until' time onto the heap
     heapq.heappush(
         scheduled_events,
-        DispatchScheduler.QueueItem(until_time, Dispatch(dispatch1)),
+        DispatchScheduler.QueueItem(until_time, Dispatch(dispatch1), True),
     )
     heapq.heappush(
         scheduled_events,
-        DispatchScheduler.QueueItem(until_time, Dispatch(dispatch2)),
+        DispatchScheduler.QueueItem(until_time, Dispatch(dispatch2), True),
     )
+
+
+def test_heapq_dispatch_start_stop_compare(test_env: TestEnv) -> None:
+    """Test that the heapq compare function works."""
+    dispatch1 = test_env.generator.generate_dispatch()
+    dispatch2 = test_env.generator.generate_dispatch()
+
+    # Simulate two dispatches with the same 'until' time
+    now = datetime.now(timezone.utc)
+    until_time = now + timedelta(minutes=5)
+
+    # Create the heap
+    scheduled_events: list[DispatchScheduler.QueueItem] = []
+
+    # Push two events with the same 'until' time onto the heap
+    heapq.heappush(
+        scheduled_events,
+        DispatchScheduler.QueueItem(until_time, Dispatch(dispatch1), stop_event=False),
+    )
+    heapq.heappush(
+        scheduled_events,
+        DispatchScheduler.QueueItem(until_time, Dispatch(dispatch2), stop_event=True),
+    )
+
+    assert scheduled_events[0].dispatch_id == dispatch1.id
+    assert scheduled_events[1].dispatch_id == dispatch2.id
 
 
 async def test_dry_run(test_env: TestEnv, fake_time: time_machine.Coordinates) -> None:


### PR DESCRIPTION
- **Add unify merge filter for dispatches**
- **Ensure that `start` events are executed before `stop` events**
- **Update release notes**
