### PR TITLE
Lengthen CI job timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,7 +185,7 @@ jobs:
             --platform linux/${{ matrix.arch }} \
             localhost/nox-cross-arch:latest \
             bash -c "pip install -e .[dev-noxfile]; nox --install-only -e ${{ matrix.nox-session }}; pip freeze; nox -R -e ${{ matrix.nox-session }}"
-        timeout-minutes: 8
+        timeout-minutes: 10
 
       # This ensures that the runner has access to the pip cache.
       - name: Reset pip cache ownership


### PR DESCRIPTION
I made it shorter once to catch flaky test that are stuck faster, but it seems the matrix job can legitimately take longer.