### PR TITLE
Deprecate DispatchInfo.components in favor of target

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ## Upgrading
 
 * The `key` parameter in the `Dispatcher` constructor is now deprecated. Use `auth_key` instead. The `sign_secret` parameter is an additional optional parameter for signing.
+* The `components` property in `DispatchInfo` is now deprecated. Use `target` instead.
 
 ## New Features
 

--- a/src/frequenz/dispatch/_actor_dispatcher.py
+++ b/src/frequenz/dispatch/_actor_dispatcher.py
@@ -15,6 +15,7 @@ from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.dispatch.types import DispatchId, TargetComponents
 from frequenz.core.id import BaseId
 from frequenz.sdk.actor import Actor, BackgroundService
+from typing_extensions import deprecated
 
 from ._dispatch import Dispatch
 
@@ -37,8 +38,18 @@ class DispatchActorId(BaseId, str_prefix="DA"):
 class DispatchInfo:
     """Event emitted when the dispatch changes."""
 
-    components: TargetComponents
-    """Components to be used."""
+    @property
+    @deprecated("'components' is deprecated, use 'target' instead.")
+    def components(self) -> TargetComponents:
+        """Get the target components.
+
+        Deprecation: Deprecated in v0.10.3
+            Use [`target`][frequenz.dispatch.DispatchInfo.target] instead.
+        """
+        return self.target
+
+    target: TargetComponents
+    """Target components to be used."""
 
     dry_run: bool
     """Whether this is a dry run."""
@@ -200,7 +211,7 @@ class ActorDispatcher(BackgroundService):
     async def _start_actor(self, dispatch: Dispatch) -> None:
         """Start the actor the given dispatch refers to."""
         dispatch_update = DispatchInfo(
-            components=dispatch.target,
+            target=dispatch.target,
             dry_run=dispatch.dry_run,
             options=dispatch.payload,
             _src=dispatch,

--- a/tests/test_managing_actor.py
+++ b/tests/test_managing_actor.py
@@ -177,9 +177,7 @@ async def test_simple_start_stop(
 
     event = test_env.actor(1).initial_dispatch
     assert event.options == {"test": True}
-    assert event.components == TargetIds(
-        ComponentId(1), ComponentId(10), ComponentId(15)
-    )
+    assert event.target == TargetIds(ComponentId(1), ComponentId(10), ComponentId(15))
     assert event.dry_run is False
 
     assert test_env.actor(1).is_running is True
@@ -309,7 +307,7 @@ async def test_dry_run(test_env: _TestEnv, fake_time: time_machine.Coordinates) 
     event = test_env.actor(1).initial_dispatch
 
     assert event.dry_run is dispatch.dry_run
-    assert event.components == dispatch.target
+    assert event.target == dispatch.target
     assert event.options == dispatch.payload
     assert test_env.actor(1).is_running is True
 


### PR DESCRIPTION
## Summary
- Rename `DispatchInfo`'s `components` property to `target` in a backwards compatible way with deprecation warning
- Update release notes to document the deprecation

This change maintains backward compatibility by keeping the `components` property as a deprecated alias for `target`.