### PR TITLE
Prepare for v1: Update auth parameters and client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ async def create_actor(dispatch: DispatchInfo, receiver: Receiver[DispatchInfo])
 
 async def run():
     url = os.getenv("DISPATCH_API_URL", "grpc://dispatch.url.goes.here.example.com")
-    key  = os.getenv("DISPATCH_API_KEY", "some-key")
+    auth_key = os.getenv("DISPATCH_API_AUTH_KEY", "some-key")
+    sign_secret = os.getenv("DISPATCH_API_SIGN_SECRET")
 
     microgrid_id = 1
 
     async with Dispatcher(
         microgrid_id=microgrid_id,
         server_url=url,
-        key=key,
+        auth_key=auth_key,
+        sign_secret=sign_secret,
     ) as dispatcher:
         await dispatcher.start_managing(
             dispatch_type="EXAMPLE_TYPE",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,12 +2,13 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This is the first major version release with authentication parameter updates and dependency version expansion.
 
 ## Upgrading
 
-* The `key` parameter in the `Dispatcher` constructor is now deprecated. Use `auth_key` instead. The `sign_secret` parameter is an additional optional parameter for signing.
-* The `components` property in `DispatchInfo` is now deprecated. Use `target` instead.
+* The `key` parameter in the `Dispatcher` constructor is deprecated. Use `auth_key` instead.
+* The `sign_secret` parameter is available and should be used for authentication. It will be soon required.
+* The `components` property in `DispatchInfo` is deprecated. Use `target` instead.
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   # plugins.mkdocstrings.handlers.python.import)
   "frequenz-sdk >= 1.0.0-rc2100, < 1.0.0-rc2200",
   "frequenz-channels >= 1.6.1, < 2.0.0",
-  "frequenz-client-dispatch >= 0.11.3, < 0.12.0",
+  "frequenz-client-dispatch >= 0.11.3, < 1.0.0",
   "frequenz-client-base >= 0.11.0, < 0.12.0",
 ]
 dynamic = ["version"]

--- a/src/frequenz/dispatch/_actor_dispatcher.py
+++ b/src/frequenz/dispatch/_actor_dispatcher.py
@@ -181,14 +181,16 @@ class ActorDispatcher(BackgroundService):
 
     async def main():
         url = os.getenv("DISPATCH_API_URL", "grpc://dispatch.url.goes.here.example.com")
-        key  = os.getenv("DISPATCH_API_KEY", "some-key")
+        auth_key = os.getenv("DISPATCH_API_AUTH_KEY", "some-key")
+        sign_secret = os.getenv("DISPATCH_API_SIGN_SECRET")
 
         microgrid_id = 1
 
         async with Dispatcher(
             microgrid_id=microgrid_id,
             server_url=url,
-            key=key
+            auth_key=auth_key,
+            sign_secret=sign_secret,
         ) as dispatcher:
             status_receiver = dispatcher.new_running_state_event_receiver("EXAMPLE_TYPE")
 


### PR DESCRIPTION
## Summary
- Update documentation to use new `auth_key` and `sign_secret` parameters instead of deprecated `key` parameter
- Update environment variable names from `DISPATCH_API_KEY` to `DISPATCH_API_AUTH_KEY` and add `DISPATCH_API_SIGN_SECRET`
- Update dispatch client version constraint from < 0.12.0 to < 1.0.0 to prepare for v1 release