### PR TITLE
Fix wrong dependabot-auto-approve hash

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: frequenz-floss/dependabot-auto-approve@005e52004f5d5c6af2f81b89ec25e5cf6f3dfd77 # v1.3.0
+      - uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1 # v1.3.2
         with:
           dependency-type: 'all'
           auto-merge: 'true'


### PR DESCRIPTION
## Summary
- Fix commit hash reference to use v1.3.2 instead of v1.3.0 in the dependabot-auto-approve workflow