### PR TITLE
Bump frequenz-repo-config from 0.13.5 to 0.13.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 80.9.0",
   "setuptools_scm[toml] == 9.2.0",
-  "frequenz-repo-config[lib] == 0.13.5",
+  "frequenz-repo-config[lib] == 0.13.8",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -68,7 +68,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.7.0",
   "mkdocstrings[python] == 0.30.1",
   "mkdocstrings-python == 1.18.2",
-  "frequenz-repo-config[lib] == 0.13.5",
+  "frequenz-repo-config[lib] == 0.13.8",
 ]
 dev-mypy = [
   "mypy == 1.19.0",
@@ -81,7 +81,7 @@ dev-mypy = [
 dev-noxfile = [
   "uv == 0.9.13",
   "nox == 2025.11.12",
-  "frequenz-repo-config[lib] == 0.13.5",
+  "frequenz-repo-config[lib] == 0.13.8",
 ]
 dev-pylint = [
   "pylint == 3.3.8",
@@ -90,7 +90,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 8.4.2",
-  "frequenz-repo-config[extra-lint-examples] == 0.13.5",
+  "frequenz-repo-config[extra-lint-examples] == 0.13.8",
   "pytest-mock == 3.15.1",
   "pytest-asyncio == 1.2.0",
   "async-solipsism == 0.8",


### PR DESCRIPTION
- Update frequenz-repo-config to 0.13.8 which adds support for pylint 4.x

This unblocks the dependabot PRs #207 (pylint 4.0.2) and #210 (isort 7.0.0).