### PR TITLE
Use common API credential variables in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ from frequenz.dispatch import Created, Deleted, Dispatcher, Updated
 
 async def main() -> None:
     url = os.getenv("DISPATCH_API_URL", "grpc://localhost:50051")
-    auth_key = os.getenv("DISPATCH_API_AUTH_KEY", "my-api-key")
-    sign_secret = os.getenv("DISPATCH_API_SIGN_SECRET")
+    auth_key = os.getenv("FREQUENZ_API_KEY", "my-api-key")
+    sign_secret = os.getenv("FREQUENZ_API_SECRET")
     microgrid_id = 1
 
     async with Dispatcher(
@@ -118,8 +118,8 @@ async def run() -> None:
     url = os.getenv(
         "DISPATCH_API_URL", "grpc://dispatch.api.example.com:50051"
     )
-    auth_key = os.getenv("DISPATCH_API_AUTH_KEY", "my-api-key")
-    sign_secret = os.getenv("DISPATCH_API_SIGN_SECRET")
+    auth_key = os.getenv("FREQUENZ_API_KEY", "my-api-key")
+    sign_secret = os.getenv("FREQUENZ_API_SECRET")
 
     microgrid_id = 1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,8 @@
 
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
+- Credential examples now use `FREQUENZ_API_KEY` and `FREQUENZ_API_SECRET`.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/src/frequenz/dispatch/_actor_dispatcher.py
+++ b/src/frequenz/dispatch/_actor_dispatcher.py
@@ -181,8 +181,8 @@ class ActorDispatcher(BackgroundService):
 
         async def main():
             url = os.getenv("DISPATCH_API_URL", "grpc://dispatch.url.goes.here.example.com")
-            auth_key = os.getenv("DISPATCH_API_AUTH_KEY", "some-key")
-            sign_secret = os.getenv("DISPATCH_API_SIGN_SECRET")
+            auth_key = os.getenv("FREQUENZ_API_KEY", "some-key")
+            sign_secret = os.getenv("FREQUENZ_API_SECRET")
 
             microgrid_id = 1
 

--- a/src/frequenz/dispatch/_dispatcher.py
+++ b/src/frequenz/dispatch/_dispatcher.py
@@ -59,14 +59,14 @@ class Dispatcher(BackgroundService):
 
         async def run():
             url = os.getenv("DISPATCH_API_URL", "grpc://dispatch.url.goes.here.example.com")
-            key = os.getenv("DISPATCH_API_KEY", "some-key")
+            auth_key = os.getenv("FREQUENZ_API_KEY", "some-key")
 
             microgrid_id = 1
 
             async with Dispatcher(
                 microgrid_id=microgrid_id,
                 server_url=url,
-                auth_key=key
+                auth_key=auth_key
             ) as dispatcher:
                 await dispatcher.start_managing(
                     dispatch_type="DISPATCH_TYPE",
@@ -85,14 +85,14 @@ class Dispatcher(BackgroundService):
 
         async def run():
             url = os.getenv("DISPATCH_API_URL", "grpc://dispatch.url.goes.here.example.com")
-            key = os.getenv("DISPATCH_API_KEY", "some-key")
+            auth_key = os.getenv("FREQUENZ_API_KEY", "some-key")
 
             microgrid_id = 1
 
             async with Dispatcher(
                 microgrid_id=microgrid_id,
                 server_url=url,
-                auth_key=key
+                auth_key=auth_key
             ) as dispatcher:
                 actor = MagicMock() # replace with your actor
 
@@ -130,14 +130,14 @@ class Dispatcher(BackgroundService):
 
         async def run():
             url = os.getenv("DISPATCH_API_URL", "grpc://dispatch.url.goes.here.example.com")
-            key = os.getenv("DISPATCH_API_KEY", "some-key")
+            auth_key = os.getenv("FREQUENZ_API_KEY", "some-key")
 
             microgrid_id = 1
 
             async with Dispatcher(
                 microgrid_id=microgrid_id,
                 server_url=url,
-                auth_key=key,
+                auth_key=auth_key,
             ) as dispatcher:
                 events_receiver = dispatcher.new_lifecycle_events_receiver("DISPATCH_TYPE")
 
@@ -167,14 +167,14 @@ class Dispatcher(BackgroundService):
 
         async def run():
             url = os.getenv("DISPATCH_API_URL", "grpc://dispatch.url.goes.here.example.com")
-            key = os.getenv("DISPATCH_API_KEY", "some-key")
+            auth_key = os.getenv("FREQUENZ_API_KEY", "some-key")
 
             microgrid_id = 1
 
             async with Dispatcher(
                 microgrid_id=microgrid_id,
                 server_url=url,
-                auth_key=key,
+                auth_key=auth_key,
             ) as dispatcher:
                 # Create a new dispatch
                 new_dispatch = await dispatcher.client.create(


### PR DESCRIPTION
Updates credential examples to use `FREQUENZ_API_KEY` and `FREQUENZ_API_SECRET`, following frequenz-io/rnd#187.

No runtime credential handling changes.